### PR TITLE
Updated Consul version to 1.2.2. to include Connect

### DIFF
--- a/terraform/multi-region/_interface.tf
+++ b/terraform/multi-region/_interface.tf
@@ -17,7 +17,7 @@ variable "auto_join_tenant_id" {
 
 # Optional variables
 variable "consul_version" {
-  default     = "1.0.0"
+  default     = "1.2.2"
   description = "Consul version to use"
 }
 

--- a/terraform/single-region/_interface.tf
+++ b/terraform/single-region/_interface.tf
@@ -17,7 +17,7 @@ variable "auto_join_tenant_id" {
 
 # Optional variables
 variable "consul_version" {
-  default     = "1.0.0"
+  default     = "1.2.2"
   description = "Consul version to use"
 }
 


### PR DESCRIPTION
Updating Consul version variable to ensure we install 1.2.2 which has Connect. If there's a better way to grab the latest Consul version by default, that would probably be better here.