### PR TITLE
upgrades to terraform version 0.12

### DIFF
--- a/terraform/modules/consul-azure/_interface.tf
+++ b/terraform/modules/consul-azure/_interface.tf
@@ -61,7 +61,7 @@ variable "consul_join_wan" {
 
 # Outputs
 output "consul_private_ips" {
-  value = ["${azurerm_network_interface.consul.*.private_ip_address}"]
+  value = azurerm_network_interface.consul.*.private_ip_address
 }
 
 output "os_user" {

--- a/terraform/modules/consul-azure/instances-consul.tf
+++ b/terraform/modules/consul-azure/instances-consul.tf
@@ -4,7 +4,7 @@ resource "azurerm_virtual_machine" "consul" {
   name                  = "${var.consul_datacenter}-${count.index}"
   location              = "${var.location}"
   resource_group_name   = "${var.resource_group_name}"
-  network_interface_ids = ["${element(azurerm_network_interface.consul.*.id,count.index)}"]
+  network_interface_ids = [azurerm_network_interface.consul.*.id[count.index]]
   vm_size               = "${var.vm_size}"
 
   # Uncomment this line to delete the OS disk automatically when deleting the VM
@@ -43,7 +43,7 @@ resource "azurerm_virtual_machine" "consul" {
     }
   }
 
-  tags {
+  tags = {
     consul_datacenter = "${var.consul_datacenter}"
   }
 }
@@ -57,11 +57,11 @@ resource "azurerm_network_interface" "consul" {
 
   ip_configuration {
     name                          = "${var.consul_datacenter}-${count.index}"
-    subnet_id                     = "${element(var.private_subnet_ids,count.index)}"
+    subnet_id                     = var.private_subnet_ids[count.index]
     private_ip_address_allocation = "dynamic"
   }
 
-  tags {
+  tags = {
     consul_datacenter = "${var.consul_datacenter}"
   }
 }

--- a/terraform/modules/network-azure/_interface.tf
+++ b/terraform/modules/network-azure/_interface.tf
@@ -55,7 +55,7 @@ output "virtual_network_id" {
 }
 
 output "jumphost_ips_public" {
-  value = ["${azurerm_public_ip.jumphost.*.ip_address}"]
+  value = azurerm_public_ip.jumphost.*.ip_address
 }
 
 output "jumphost_username" {
@@ -63,9 +63,9 @@ output "jumphost_username" {
 }
 
 output "subnet_public_ids" {
-  value = ["${azurerm_subnet.public.*.id}"]
+  value = azurerm_subnet.public.*.id
 }
 
 output "subnet_private_ids" {
-  value = ["${azurerm_subnet.private.*.id}"]
+  value = azurerm_subnet.private.*.id
 }

--- a/terraform/modules/network-azure/instances-jumphost.tf
+++ b/terraform/modules/network-azure/instances-jumphost.tf
@@ -4,7 +4,7 @@ resource "azurerm_virtual_machine" "jumphost" {
   name                  = "${var.network_name}-jumphost-${count.index}"
   location              = "${var.location}"
   resource_group_name   = "${var.resource_group_name}"
-  network_interface_ids = ["${element(azurerm_network_interface.jumphost.*.id,count.index)}"]
+  network_interface_ids = [azurerm_network_interface.jumphost.*.id[count.index]]
   vm_size               = "${var.jumphost_vm_size}"
 
   # Uncomment this line to delete the OS disk automatically when deleting the VM
@@ -42,7 +42,7 @@ resource "azurerm_virtual_machine" "jumphost" {
     }
   }
 
-  tags {
+  tags = {
     network_name = "${var.network_name}-jumphost-${count.index}"
   }
 }
@@ -58,8 +58,8 @@ resource "azurerm_network_interface" "jumphost" {
 
   ip_configuration {
     name                          = "${var.network_name}-jumphost-${count.index}"
-    subnet_id                     = "${element(azurerm_subnet.public.*.id,count.index)}"
-    public_ip_address_id          = "${element(azurerm_public_ip.jumphost.*.id,count.index)}"
+    subnet_id                     = azurerm_subnet.public.*.id[count.index]
+    public_ip_address_id          = azurerm_public_ip.jumphost.*.id[count.index]
     private_ip_address_allocation = "dynamic"
   }
 }
@@ -70,7 +70,7 @@ resource "azurerm_public_ip" "jumphost" {
   name                         = "${var.network_name}-jumphost-${count.index}"
   location                     = "${var.location}"
   resource_group_name          = "${var.resource_group_name}"
-  public_ip_address_allocation = "static"
+  allocation_method = "Static"
 }
 
 resource "random_id" "jumphost" {

--- a/terraform/modules/network-azure/subnets.tf
+++ b/terraform/modules/network-azure/subnets.tf
@@ -4,7 +4,7 @@ resource "azurerm_subnet" "public" {
   name                 = "${var.network_name}-public-${count.index}"
   resource_group_name  = "${var.resource_group_name}"
   virtual_network_name = "${azurerm_virtual_network.main.name}"
-  address_prefix       = "${element(var.network_cidrs_public,count.index)}"
+  address_prefix       = var.network_cidrs_public[count.index]
 }
 
 resource "azurerm_subnet" "private" {
@@ -13,5 +13,5 @@ resource "azurerm_subnet" "private" {
   name                 = "${var.network_name}-private-${count.index}"
   resource_group_name  = "${var.resource_group_name}"
   virtual_network_name = "${azurerm_virtual_network.main.name}"
-  address_prefix       = "${element(var.network_cidrs_private,count.index)}"
+  address_prefix       = var.network_cidrs_private[count.index]
 }

--- a/terraform/multi-region/_interface.tf
+++ b/terraform/multi-region/_interface.tf
@@ -1,18 +1,18 @@
 # Required variables (defined in terraform.tfvars)
 variable "auto_join_subscription_id" {
-  type = "string"
+  type = string
 }
 
 variable "auto_join_client_id" {
-  type = "string"
+  type = string
 }
 
 variable "auto_join_client_secret" {
-  type = "string"
+  type = string
 }
 
 variable "auto_join_tenant_id" {
-  type = "string"
+  type = string
 }
 
 # Optional variables
@@ -49,17 +49,38 @@ variable "private_key_filename" {
 # Outputs
 
 output "jumphost_westus_ssh_connection_strings" {
-  value = "${formatlist("ssh-add %s && ssh -A -i %s %s@%s", var.private_key_filename, var.private_key_filename, module.network_westus.jumphost_username, module.network_westus.jumphost_ips_public)}"
+  value = formatlist(
+    "ssh-add %s && ssh -A -i %s %s@%s",
+    var.private_key_filename,
+    var.private_key_filename,
+    module.network_westus.jumphost_username,
+    module.network_westus.jumphost_ips_public,
+  )
 }
 
 output "consul_private_ips_westus" {
-  value = "${formatlist("ssh %s@%s", module.consul_azure_westus.os_user, module.consul_azure_westus.consul_private_ips)}"
+  value = formatlist(
+    "ssh %s@%s",
+    module.consul_azure_westus.os_user,
+    module.consul_azure_westus.consul_private_ips,
+  )
 }
 
 output "jumphost_eastus_ssh_connection_strings" {
-  value = "${formatlist("ssh-add %s && ssh -A -i %s %s@%s", var.private_key_filename, var.private_key_filename, module.network_eastus.jumphost_username, module.network_eastus.jumphost_ips_public)}"
+  value = formatlist(
+    "ssh-add %s && ssh -A -i %s %s@%s",
+    var.private_key_filename,
+    var.private_key_filename,
+    module.network_eastus.jumphost_username,
+    module.network_eastus.jumphost_ips_public,
+  )
 }
 
 output "consul_private_ips_eastus" {
-  value = "${formatlist("ssh %s@%s", module.consul_azure_eastus.os_user, module.consul_azure_eastus.consul_private_ips)}"
+  value = formatlist(
+    "ssh %s@%s",
+    module.consul_azure_eastus.os_user,
+    module.consul_azure_eastus.consul_private_ips,
+  )
 }
+

--- a/terraform/multi-region/main.tf
+++ b/terraform/multi-region/main.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.10.1"
+  required_version = ">= 0.12.0"
 }
 
-provider "azurerm" {}
+provider "azurerm" {
+}
 
 resource "azurerm_resource_group" "main" {
   name     = "consul-multi-region"
@@ -12,74 +13,74 @@ resource "azurerm_resource_group" "main" {
 module "ssh_key" {
   source = "../modules/ssh-keypair-data"
 
-  private_key_filename = "${var.private_key_filename}"
+  private_key_filename = var.private_key_filename
 }
 
 module "network_westus" {
   source                = "../modules/network-azure"
-  resource_group_name   = "${azurerm_resource_group.main.name}"
+  resource_group_name   = azurerm_resource_group.main.name
   location              = "westus"
   network_name          = "consul-westus"
   network_cidr          = "10.0.0.0/16"
   network_cidrs_public  = ["10.0.0.0/20"]
   network_cidrs_private = ["10.0.48.0/20", "10.0.64.0/20", "10.0.80.0/20"]
-  os                    = "${var.os}"
-  public_key_data       = "${module.ssh_key.public_key_data}"
+  os                    = var.os
+  public_key_data       = module.ssh_key.public_key_data
 }
 
 module "network_eastus" {
   source                = "../modules/network-azure"
-  resource_group_name   = "${azurerm_resource_group.main.name}"
+  resource_group_name   = azurerm_resource_group.main.name
   location              = "eastus"
   network_name          = "consul-eastus"
   network_cidr          = "10.1.0.0/16"
   network_cidrs_public  = ["10.1.0.0/20"]
   network_cidrs_private = ["10.1.48.0/20", "10.1.64.0/20", "10.1.80.0/20"]
-  os                    = "${var.os}"
-  public_key_data       = "${module.ssh_key.public_key_data}"
+  os                    = var.os
+  public_key_data       = module.ssh_key.public_key_data
 }
 
 module "consul_azure_westus" {
   source                    = "../modules/consul-azure"
-  resource_group_name       = "${azurerm_resource_group.main.name}"
+  resource_group_name       = azurerm_resource_group.main.name
   consul_datacenter         = "consul-westus"
   consul_join_wan           = ["consul-eastus"]
   location                  = "westus"
-  cluster_size              = "${var.cluster_size}"
-  private_subnet_ids        = ["${module.network_westus.subnet_private_ids}"]
-  consul_version            = "${var.consul_version}"
-  vm_size                   = "${var.consul_vm_size}"
-  os                        = "${var.os}"
-  public_key_data           = "${module.ssh_key.public_key_data}"
-  auto_join_subscription_id = "${var.auto_join_subscription_id}"
-  auto_join_tenant_id       = "${var.auto_join_tenant_id}"
-  auto_join_client_id       = "${var.auto_join_client_id}"
-  auto_join_client_secret   = "${var.auto_join_client_secret}"
+  cluster_size              = var.cluster_size
+  private_subnet_ids        = module.network_westus.subnet_private_ids
+  consul_version            = var.consul_version
+  vm_size                   = var.consul_vm_size
+  os                        = var.os
+  public_key_data           = module.ssh_key.public_key_data
+  auto_join_subscription_id = var.auto_join_subscription_id
+  auto_join_tenant_id       = var.auto_join_tenant_id
+  auto_join_client_id       = var.auto_join_client_id
+  auto_join_client_secret   = var.auto_join_client_secret
 }
 
 module "consul_azure_eastus" {
   source                    = "../modules/consul-azure"
-  resource_group_name       = "${azurerm_resource_group.main.name}"
+  resource_group_name       = azurerm_resource_group.main.name
   consul_datacenter         = "consul-eastus"
   consul_join_wan           = ["consul-westus"]
   location                  = "eastus"
-  cluster_size              = "${var.cluster_size}"
-  private_subnet_ids        = ["${module.network_eastus.subnet_private_ids}"]
-  consul_version            = "${var.consul_version}"
-  vm_size                   = "${var.consul_vm_size}"
-  os                        = "${var.os}"
-  public_key_data           = "${module.ssh_key.public_key_data}"
-  auto_join_subscription_id = "${var.auto_join_subscription_id}"
-  auto_join_tenant_id       = "${var.auto_join_tenant_id}"
-  auto_join_client_id       = "${var.auto_join_client_id}"
-  auto_join_client_secret   = "${var.auto_join_client_secret}"
+  cluster_size              = var.cluster_size
+  private_subnet_ids        = module.network_eastus.subnet_private_ids
+  consul_version            = var.consul_version
+  vm_size                   = var.consul_vm_size
+  os                        = var.os
+  public_key_data           = module.ssh_key.public_key_data
+  auto_join_subscription_id = var.auto_join_subscription_id
+  auto_join_tenant_id       = var.auto_join_tenant_id
+  auto_join_client_id       = var.auto_join_client_id
+  auto_join_client_secret   = var.auto_join_client_secret
 }
 
 resource "azurerm_virtual_network_peering" "peer-westus-to-eastus" {
   name                         = "peer-westus-to-eastus"
-  resource_group_name          = "${azurerm_resource_group.main.name}"
-  virtual_network_name         = "${module.network_westus.virtual_network_name}"
-  remote_virtual_network_id    = "${module.network_eastus.virtual_network_id}"
+  resource_group_name          = azurerm_resource_group.main.name
+  virtual_network_name         = module.network_westus.virtual_network_name
+  remote_virtual_network_id    = module.network_eastus.virtual_network_id
   allow_virtual_network_access = true
   allow_forwarded_traffic      = true
 
@@ -89,12 +90,13 @@ resource "azurerm_virtual_network_peering" "peer-westus-to-eastus" {
 
 resource "azurerm_virtual_network_peering" "peer-eastus-to-westus" {
   name                         = "peer-eastus-to-westus"
-  resource_group_name          = "${azurerm_resource_group.main.name}"
-  virtual_network_name         = "${module.network_eastus.virtual_network_name}"
-  remote_virtual_network_id    = "${module.network_westus.virtual_network_id}"
+  resource_group_name          = azurerm_resource_group.main.name
+  virtual_network_name         = module.network_eastus.virtual_network_name
+  remote_virtual_network_id    = module.network_westus.virtual_network_id
   allow_virtual_network_access = true
   allow_forwarded_traffic      = true
 
   # `allow_gateway_transit` must be set to false for vnet Global Peering
   allow_gateway_transit = false
 }
+

--- a/terraform/single-region/_interface.tf
+++ b/terraform/single-region/_interface.tf
@@ -1,18 +1,18 @@
 # Required variables (defined in terraform.tfvars)
 variable "auto_join_subscription_id" {
-  type = "string"
+  type = string
 }
 
 variable "auto_join_client_id" {
-  type = "string"
+  type = string
 }
 
 variable "auto_join_client_secret" {
-  type = "string"
+  type = string
 }
 
 variable "auto_join_tenant_id" {
-  type = "string"
+  type = string
 }
 
 # Optional variables
@@ -49,9 +49,20 @@ variable "private_key_filename" {
 # Outputs
 
 output "jumphost_westus_ssh_connection_strings" {
-  value = "${formatlist("ssh-add %s && ssh -A -i %s %s@%s", var.private_key_filename, var.private_key_filename, module.network_westus.jumphost_username, module.network_westus.jumphost_ips_public)}"
+  value = formatlist(
+    "ssh-add %s && ssh -A -i %s %s@%s",
+    var.private_key_filename,
+    var.private_key_filename,
+    module.network_westus.jumphost_username,
+    module.network_westus.jumphost_ips_public,
+  )
 }
 
 output "consul_private_ips_westus" {
-  value = "${formatlist("ssh %s@%s", module.consul_azure_westus.os_user, module.consul_azure_westus.consul_private_ips)}"
+  value = formatlist(
+    "ssh %s@%s",
+    module.consul_azure_westus.os_user,
+    module.consul_azure_westus.consul_private_ips,
+  )
 }
+

--- a/terraform/single-region/main.tf
+++ b/terraform/single-region/main.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.10.1"
+  required_version = ">= 0.12"
 }
 
-provider "azurerm" {}
+provider "azurerm" {
+}
 
 resource "azurerm_resource_group" "main" {
   name     = "consul-single-region"
@@ -12,34 +13,35 @@ resource "azurerm_resource_group" "main" {
 module "ssh_key" {
   source = "../modules/ssh-keypair-data"
 
-  private_key_filename = "${var.private_key_filename}"
+  private_key_filename = var.private_key_filename
 }
 
 module "network_westus" {
   source                = "../modules/network-azure"
-  resource_group_name   = "${azurerm_resource_group.main.name}"
+  resource_group_name   = azurerm_resource_group.main.name
   location              = "westus"
   network_name          = "consul-westus"
   network_cidr          = "10.0.0.0/16"
   network_cidrs_public  = ["10.0.0.0/20"]
   network_cidrs_private = ["10.0.48.0/20", "10.0.64.0/20", "10.0.80.0/20"]
-  os                    = "${var.os}"
-  public_key_data       = "${module.ssh_key.public_key_data}"
+  os                    = var.os
+  public_key_data       = module.ssh_key.public_key_data
 }
 
 module "consul_azure_westus" {
   source                    = "../modules/consul-azure"
-  resource_group_name       = "${azurerm_resource_group.main.name}"
+  resource_group_name       = azurerm_resource_group.main.name
   consul_datacenter         = "consul-westus"
   location                  = "westus"
-  cluster_size              = "${var.cluster_size}"
-  private_subnet_ids        = ["${module.network_westus.subnet_private_ids}"]
-  consul_version            = "${var.consul_version}"
-  vm_size                   = "${var.consul_vm_size}"
-  os                        = "${var.os}"
-  public_key_data           = "${module.ssh_key.public_key_data}"
-  auto_join_subscription_id = "${var.auto_join_subscription_id}"
-  auto_join_tenant_id       = "${var.auto_join_tenant_id}"
-  auto_join_client_id       = "${var.auto_join_client_id}"
-  auto_join_client_secret   = "${var.auto_join_client_secret}"
+  cluster_size              = var.cluster_size
+  private_subnet_ids        = module.network_westus.subnet_private_ids
+  consul_version            = var.consul_version
+  vm_size                   = var.consul_vm_size
+  os                        = var.os
+  public_key_data           = module.ssh_key.public_key_data
+  auto_join_subscription_id = var.auto_join_subscription_id
+  auto_join_tenant_id       = var.auto_join_tenant_id
+  auto_join_client_id       = var.auto_join_client_id
+  auto_join_client_secret   = var.auto_join_client_secret
 }
+


### PR DESCRIPTION
I noticed this sample is behind a few versions, this pull request runs :

```
cd terraform/muti-region
terraform init
terraform 0.12upgrade


cd terraform/single-region
terraform init
terraform 0.12upgrade
```

I then went in and fixed any places where lists were using the older syntax. 